### PR TITLE
Support Vagrant

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,5 @@ Makefile
 *.bundle
 *.log
 pkg
+.vagrant
 

--- a/README
+++ b/README
@@ -53,3 +53,24 @@ Ruby binding:
 If you just want to use the C API, download the .tar.gz from:
 
 http://rubyforge.org/frs/?group_id=7925
+
+DEVLOPMENT
+==========
+
+Install [vagrant](https://www.vagrantup.com/).
+
+```
+$ vagrant up
+```
+
+Installs a VM with all the pieces needed for development
+
+```
+$ vagrant ssh
+$ cd /vagrant
+$ rake santity_test
+```
+
+Runs the sanity test on the vagrant box now.
+
+

--- a/Rakefile
+++ b/Rakefile
@@ -24,6 +24,7 @@ task :changelog do
   }
 end
 
+desc "Run the tests"
 task :sanity_test do
   sh "./src/tests/sanity-test"
 end
@@ -65,7 +66,7 @@ begin
   require 'rake'
   require 'rake/clean'
   require 'rake/packagetask'
-  require 'rake/gempackagetask'
+  require 'rubygems/package_task'
   require 'fileutils'
 rescue LoadError
 else
@@ -98,10 +99,10 @@ alternative to GDBM and Berkeley DB.
     s.rubyforge_project = 'localmemcache'
   end
 
-  Rake::GemPackageTask.new(spec) do |p|
-    p.gem_spec = spec
-    p.need_tar = false
+  Rake::PackageTask.new(spec.name, spec.version.to_s) do |p|
+    p.package_files = spec.files
     p.need_zip = false
+    p.need_tar = false
   end
 
 end

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,37 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = "2"
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+  config.vm.box = "hashicorp/precise32"
+
+  config.vm.provision 'shell', :inline => <<-SCRIPT, :privileged => false
+    set -e
+    set -x
+    # apt-get stuff, all together to perform only one "update".
+    PACKAGES="curl git build-essential"
+    dpkg -s $PACKAGES >/dev/null || {
+      sudo apt-get -y update
+      sudo apt-get -y install $PACKAGES
+    }
+    set +x # rvm vomits a ton of output with set -x, so we silence it.
+    command -v rvm >/dev/null || {
+      gpg --keyserver hkp://keys.gnupg.net --recv-keys D39DC0E3
+      curl -sSL https://get.rvm.io | bash -s stable
+    }
+    . ~/.bashrc
+    . ~/.profile
+    rvm --default use 1.9.3 >/dev/null || {
+      rvm install 1.9.3
+      rvm --default use 1.9.3
+    };
+    set -x
+    command -v bundle >/dev/null || {
+      gem install bundler
+    }
+    command -v rake >/dev/null || {
+      gem install rake
+    }
+  SCRIPT
+end


### PR DESCRIPTION
Make it easier to get started by allowing to just run `vagrant up` which
sets up a ubuntu VM with all the pieces installed to run `rake
sanity_test` to run the tests.
