### PR TITLE
Update .gitignore to ignore ctags, global files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,4 +18,8 @@ Makefile
 *.log
 pkg
 .vagrant
-
+TAGS
+tags
+GPATH
+GRTAGS
+GTAGS


### PR DESCRIPTION
I update .gitignore file to ignore the files which is generated by the source reading tools: ctags, global.
