### PR TITLE
Refactoring sanity-test script to understand which line causes the er…

### DIFF
--- a/src/tests/sanity-test
+++ b/src/tests/sanity-test
@@ -1,7 +1,16 @@
 #! /bin/sh
 
-./configure && make -C src clean && make -C src && \
-  (cd src/ruby-binding; ruby extconf.rb) && \
-  make -C src/ruby-binding/ && \
-  (cd src/tests; ruby extconf.rb) && \
-  make -C src/tests/ && ./src/tests/lmc 
+# -v: verbose, print command line.
+set -v
+
+./configure || exit 1
+
+make -C src clean || exit 1
+make -C src || exit 1
+
+(cd src/ruby-binding; ruby extconf.rb) || exit 1
+make -C src/ruby-binding/ || exit 1
+
+(cd src/tests; ruby extconf.rb) || exit 1
+make -C src/tests/ || exit 1
+./src/tests/lmc || exit 1


### PR DESCRIPTION
I did refactoring sanity-test script to understand which line causes the error, when test is failed.

As a information, I did not use "set -e" which is the option of when each command in the main script finishes as a non-zero status, main script will finish.
Because when we use "set -e", any subcommand or pipeline return non-zero status in the main script, the main script finishes.
We need to use "-e" carefully.
